### PR TITLE
In gatt_server.py, use GATT_MANAGER_IFACE

### DIFF
--- a/gatt_server.py
+++ b/gatt_server.py
@@ -612,7 +612,7 @@ def register_app_error_cb(mainloop, error):
 def gatt_server_main(mainloop, bus, adapter_name):
     adapter = adapters.find_adapter(bus, GATT_MANAGER_IFACE, adapter_name)
     if not adapter:
-        raise Exception('GattManager1 interface not found')
+        raise Exception('%s interface not found' % GATT_MANAGER_IFACE)
 
     service_manager = dbus.Interface(
             bus.get_object(BLUEZ_SERVICE_NAME, adapter),


### PR DESCRIPTION
Use the variable instead of the hardcoded name "GattManager1"